### PR TITLE
Add support for remote radio connections via hostname

### DIFF
--- a/src/discovery.h
+++ b/src/discovery.h
@@ -24,3 +24,4 @@ extern int  discover_only_stemlab;
 extern int delayed_discovery(gpointer data);
 extern void discovery(void);
 extern char *ipaddr_radio;
+extern int radio_port;

--- a/src/new_discovery.c
+++ b/src/new_discovery.c
@@ -181,7 +181,7 @@ static void new_discover(struct ifaddrs* iface, int discflag) {
 
     // setup to address
     to_addr.sin_family = AF_INET;
-    to_addr.sin_port = htons(DISCOVERY_PORT);
+    to_addr.sin_port = htons(radio_port);
     to_addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
     //
     // This will use the subnet-specific broadcast address
@@ -216,7 +216,7 @@ static void new_discover(struct ifaddrs* iface, int discflag) {
     interface_addr.sin_addr.s_addr = htonl(INADDR_ANY);
     memset(&to_addr, 0, sizeof(to_addr));
     to_addr.sin_family = AF_INET;
-    to_addr.sin_port = htons(DISCOVERY_PORT);
+    to_addr.sin_port = htons(radio_port);
 
     if (inet_aton(ipaddr_radio, &to_addr.sin_addr) == 0) {
       return;

--- a/src/old_discovery.c
+++ b/src/old_discovery.c
@@ -126,7 +126,7 @@ static void discover(struct ifaddrs* iface, int discflag) {
 
     // setup to address
     to_addr.sin_family = AF_INET;
-    to_addr.sin_port = htons(DISCOVERY_PORT);
+    to_addr.sin_port = htons(radio_port);
     to_addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
     //
     // This will use the subnet-specific broadcast address
@@ -162,7 +162,7 @@ static void discover(struct ifaddrs* iface, int discflag) {
     interface_addr.sin_addr.s_addr = htonl(INADDR_ANY);
     memset(&to_addr, 0, sizeof(to_addr));
     to_addr.sin_family = AF_INET;
-    to_addr.sin_port = htons(DISCOVERY_PORT);
+    to_addr.sin_port = htons(radio_port);
 
     // Try to resolve hostname or IP address
     struct addrinfo hints, *result = NULL;
@@ -173,7 +173,7 @@ static void discover(struct ifaddrs* iface, int discflag) {
     if (getaddrinfo(ipaddr_radio, NULL, &hints, &result) == 0 && result != NULL) {
       // Successfully resolved
       memcpy(&to_addr, result->ai_addr, sizeof(struct sockaddr_in));
-      to_addr.sin_port = htons(DISCOVERY_PORT);
+      to_addr.sin_port = htons(radio_port);
       freeaddrinfo(result);
       t_print("discover: resolved %s to %s\n", ipaddr_radio, inet_ntoa(to_addr.sin_addr));
     } else {
@@ -202,7 +202,7 @@ static void discover(struct ifaddrs* iface, int discflag) {
     //
     memset(&to_addr, 0, sizeof(to_addr));
     to_addr.sin_family = AF_INET;
-    to_addr.sin_port = htons(DISCOVERY_PORT);
+    to_addr.sin_port = htons(radio_port);
 
     if (inet_aton(ipaddr_radio, &to_addr.sin_addr) == 0) {
       return;


### PR DESCRIPTION
  ## Summary
  This PR adds comprehensive support for connecting to remote radios using
  hostnames (e.g., `radio.ddns.net`) in addition to numeric IP addresses.

  ## Problem
  Currently, deskHPSDR only accepts numeric IP addresses in the "Radio IP
  Addr" field. Users with remote radios using dynamic DNS cannot use
  hostnames, requiring manual DNS resolution.

  ## Solution
  - Modified `old_discovery.c` to use `getaddrinfo()` for DNS resolution
  - Updated `discovery.c` to accept and validate both IP addresses and
  hostnames in the UI
  - Increased timeout from 2 to 10 seconds for remote connections with
  higher latency
  - Disabled TCP discovery (not needed for Protocol 1)
  - Increased `IPADDR_LEN` from 20 to 64 characters to support longer
  hostnames

  ## Testing
  - ✅ Tested with Hermes Lite 2 using Protocol 1
  - ✅ Remote connection via DDNS hostname over internet (radio.ddns.net)
  - ✅ Local connections with numeric IPs still work as before
  - ✅ Both hostname and IP address formats are accepted and validated

  ## Benefits
  - Enables remote operation without manual DNS resolution
  - Supports dynamic DNS services (e.g., ddns.net, duckdns.org)
  - Maintains backward compatibility with numeric IP addresses
  - Improves user experience for remote radio operators