### PR TITLE
Add Canada band plan option for 60m

### DIFF
--- a/src/band.c
+++ b/src/band.c
@@ -115,6 +115,14 @@ static BANDSTACK_ENTRY bandstack_entries60_UK[] = {
   {5405000LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0}
 };
 
+static BANDSTACK_ENTRY bandstack_entries60_CA[] = {
+  {5332000LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0}, // default channels for
+  {5348000LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0}, // 60m band, US regulations
+  {5358500LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0},
+  {5373000LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0},
+  {5405000LL, 0, 0LL, modeUSB, filterF5, 2500, 0, 0}
+};
+
 #if defined (__REG1__)
 static BANDSTACK_ENTRY bandstack_entries40[] = {
   {7001000LL, 0, 0LL, modeCWL, filterF6, 2500, 0, 0},
@@ -459,6 +467,13 @@ static CHANNEL band_channels_60m_US[US_CHANNEL_ENTRIES] = {
   {5405000LL, 3000LL}
 };
 
+static CHANNEL band_channels_60m_CA[CA_CHANNEL_ENTRIES] = {
+  {5332000LL, 3000LL},
+  {5348000LL, 3000LL},
+  {5359000LL, 15000LL},
+  {5373000LL, 3000LL},
+  {5405000LL, 3000LL}
+};
 //
 // channel_entires and band_channels_60m are used in the RX panadapter
 // to mark the "channels"
@@ -511,6 +526,14 @@ void radio_change_region(int r) {
     bandstack60.current_entry = 0;
     bandstack60.entry = bandstack_entries60_WRC15;
     break;
+
+  case REGION_CA:
+    channel_entries = CA_CHANNEL_ENTRIES;
+    band_channels_60m = &band_channels_60m_CA[0];
+    bandstack60.entries = CA_BANDSTACK_ENTRIES;
+    bandstack60.current_entry = 0;
+    bandstack60.entry = bandstack_entries60_CA;
+    break;    
   }
 }
 

--- a/src/band.h
+++ b/src/band.h
@@ -97,11 +97,13 @@ typedef struct _CHANNEL CHANNEL;
 #define US_BANDSTACK_ENTRIES 5
 #define VFO_BANDSTACK_ENTRIES 5
 #define WRC15_BANDSTACK_ENTRIES 5
+#define CA_BANDSTACK_ENTRIES 5
 
 #define UK_CHANNEL_ENTRIES 11
 #define US_CHANNEL_ENTRIES 5
 #define VFO_CHANNEL_ENTRIES 1
 #define WRC15_CHANNEL_ENTRIES 1
+#define CA_CHANNEL_ENTRIES 5
 
 extern int channel_entries;
 extern CHANNEL *band_channels_60m;

--- a/src/radio.h
+++ b/src/radio.h
@@ -72,7 +72,8 @@ enum _region_enum {
   REGION_VFO = 0,  // VFO mode
   REGION_UK,       // 60m band allocation for UK
   REGION_US,       // 60m band allocation for US
-  REGION_WRC15     // 60m band allocation for WRC15
+  REGION_WRC15,    // 60m band allocation for WRC15
+  REGION_CA        // 60m band allocation for CA
 };
 
 enum _capture_state {

--- a/src/radio_menu.c
+++ b/src/radio_menu.c
@@ -728,12 +728,14 @@ void radio_menu(GtkWidget *parent) {
   gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(region_combo), NULL, "UK Channels");
   gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(region_combo), NULL, "US Channels");
   gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(region_combo), NULL, "WRC15");
+  gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(region_combo), NULL, "CA Channels");
   gtk_combo_box_set_active(GTK_COMBO_BOX(region_combo), region);
   gtk_widget_set_tooltip_text(region_combo,
                               "Select an option if want see colored channel marker\nin the RX panadapter.\n\n"
                               "UK - UK Channelizing 60m\n"
                               "US - US Channelizing 60m\n"
                               "WRC15 - ONE Channel according to the WRC15 recommendation for 60m\n"
+                              "CA - CA Channelizing 60m\n"
                               "NONE - No channel markers");
   my_combo_attach(GTK_GRID(grid), region_combo, 2, row, 1, 1);
   g_signal_connect(region_combo, "changed", G_CALLBACK(region_cb), NULL);


### PR DESCRIPTION
I recently discovered that Canada's 60m band plan combines the WRC15 allocation and the US channelized frequencies. Source: www.rac.ca/rac-0-30-mhz-band-plan/

I am not Canadian, and I don't know anyone who is, but I thought this might be a nice thing to add, in case any Canadians ever want to use this. 

 Just so you know, I don't actually know how to program in C, but I have compiled this and ran it to make sure that the bandplan shows up as intended.

Thanks again for developing DeskHPSDR.