### PR TITLE
Add webkit2gtk4.1-devel to Fedora package install list

### DIFF
--- a/LINUX/prep_linux.sh
+++ b/LINUX/prep_linux.sh
@@ -173,7 +173,7 @@ sudo dnf -y install git gcc-gfortran gettext cppcheck dos2unix \
 libzstd-devel python3-devel fftw-devel gtk3-devel \
 openssl-devel alsa-lib-devel libcurl-devel  libusb1-devel \
 libgpiod-devel  pulseaudio-libs-devel  libpcap-devel  \
-json-c-devel  gnome-themes-extra  SoapySDR-devel
+json-c-devel  gnome-themes-extra  SoapySDR-devel webkit2gtk4.1-devel
 
 else
 	echo "This script is only for Debian and Fedora based or similiar LINUX distributions"


### PR DESCRIPTION
A user reported that building the latest version failed on Fedora 42 due to the webkit2gtk4.1-devel not being installed. This change adds it to the package install list. I have added this and successfully built on F43. User reported they can now build on Fedora 42. 