### PR TITLE
Support setting VFO mode via TCI modulation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1180,16 +1180,17 @@ install-Darwin: all
 	@-fc-cache -f
 	@sleep 1
 	@git update-index --assume-unchanged make.config.deskhpsdr
-	@echo "Copy deskHPSDR to your Desktop..."
-	@mv deskHPSDR.app "${HOME}/Desktop"
-	@sleep 1
 	@if [ -x /usr/bin/codesign ]; then \
+		echo "Strip extended attributes before codesigning..."; \
+		xattr -cr deskHPSDR.app; \
 		echo "Codesign deskHPSDR against possible problems with gatekeeper..."; \
-		codesign --force --deep --sign - "${HOME}/Desktop/deskHPSDR.app"; \
+		codesign --force --deep --sign - deskHPSDR.app; \
 		sleep 1; \
 		echo "Verify deskHPSDR codesign..."; \
-		codesign --verify --deep --strict --verbose=2 "${HOME}/Desktop/deskHPSDR.app"; \
+		codesign --verify --deep --strict --verbose=2 deskHPSDR.app; \
 	fi
+	@echo "Copy deskHPSDR to your Desktop..."
+	@mv deskHPSDR.app "${HOME}/Desktop"
 	@echo "Starting deskHPSDR..."
 	@open -a "${HOME}/Desktop/deskHPSDR.app"
 


### PR DESCRIPTION
## Summary

- **TCI mode setting**: The `modulation` command now supports setting the VFO mode (`modulation:x,y;`) in addition to querying it (`modulation:x;`). This allows logger programs and TCI clients to change the operating mode on the radio.
- **macOS codesign fix**: Codesign the `.app` bundle in the build directory before moving it to `~/Desktop` to avoid failures on iCloud-managed Desktops.

## Why

Logger programs like Log4YM (and any TCI-compatible logger) need to set the radio mode when the operator clicks a DX cluster spot or changes band. The logger knows the correct mode for the frequency but currently has no way to tell deskHPSDR to switch — the operator must do it manually on every QSY, which breaks the logging workflow.

The TCI protocol already defines `modulation:x,y;` for this purpose. This change implements that.

## macOS codesign

When `~/Desktop` is iCloud-managed, macOS adds extended attributes to files moved there that cause `codesign` to fail with "resource fork, Finder information, or similar detritus not allowed". Signing before the move avoids this.

## Test plan

- [ ] Verify `modulation:0;` still reports the current mode
- [ ] Send `modulation:0,usb;` and verify the VFO changes to USB
- [ ] Send `modulation:0,lsb;` and verify the VFO changes to LSB
- [ ] Verify invalid mode strings are rejected with a log message
- [ ] Run `make install` on macOS with iCloud Desktop enabled