### PR TITLE
Show network interface type in discovery results

### DIFF
--- a/src/discovery.c
+++ b/src/discovery.c
@@ -77,6 +77,52 @@ static gboolean close_cb(void) {
   return TRUE;
 }
 
+static int network_type_for_device(const DISCOVERED *dev) {
+  if (dev->protocol != ORIGINAL_PROTOCOL && dev->protocol != NEW_PROTOCOL) {
+    return -1;
+  }
+  if (dev->info.network.interface_name[0] == '\0' ||
+      strcmp(dev->info.network.interface_name, "UDP") == 0 ||
+      strcmp(dev->info.network.interface_name, "TCP") == 0 ||
+      strcmp(dev->info.network.interface_name, "USB") == 0 ||
+      strcmp(dev->info.network.interface_name, "XDMA") == 0) {
+    return -1;
+  }
+  return nw_is_wired_interface(dev->info.network.interface_name);
+}
+
+static GtkWidget *create_network_type_label(const DISCOVERED *dev) {
+  GtkWidget *label;
+  const char *text;
+  const char *tooltip;
+  int wired = network_type_for_device(dev);
+  if (wired == 1) {
+    text = "[LAN]";
+    tooltip = "Ethernet interface";
+  } else if (wired == 0) {
+    text = "[Wi-Fi]";
+    tooltip = "Wi-Fi interface";
+  } else {
+    return NULL;
+  }
+  label = gtk_label_new(text);
+  gtk_widget_set_name(label, "boldlabel_blue");
+  gtk_widget_set_tooltip_text(label, tooltip);
+  gtk_widget_set_halign(label, GTK_ALIGN_CENTER);
+  gtk_widget_set_valign(label, GTK_ALIGN_CENTER);
+  gtk_widget_set_margin_top(label, 10);
+  gtk_widget_set_margin_start(label, 2);
+  return label;
+}
+
+static void set_device_label_scale(GtkWidget *label) {
+  PangoAttrList *attrs = pango_attr_list_new();
+  PangoAttribute *scale = pango_attr_scale_new(0.92);
+  pango_attr_list_insert(attrs, scale);
+  gtk_label_set_attributes(GTK_LABEL(label), attrs);
+  pango_attr_list_unref(attrs);
+}
+
 static gboolean start_cb(GtkWidget *widget, GdkEventButton *event, gpointer data) {
   /* korrektes Gerät aus der Discover-Liste selektieren */
   selected_device = GPOINTER_TO_INT(data);
@@ -408,9 +454,11 @@ void discovery(void) {
   } else {
     char version[16];
     char text[512];
+    char tooltip[512];
     char macStr[18];
     for (row = 0; row < devices; row++) {
       d = &discovered[row];
+      tooltip[0] = '\0';
       t_print("Device Protocol=%d name=%s\n", d->protocol, d->name);
       snprintf(version, sizeof(version), "v%d.%d",
                d->software_version / 10,
@@ -433,10 +481,15 @@ void discovery(void) {
                    d->protocol == ORIGINAL_PROTOCOL ? "Protocol 1" : "Protocol 2", d->software_version,
                    d->fpga_version, macStr);
         } else {
-          snprintf(text, sizeof(text), "%s %s (%s) %s (%s) on %s: ",
+          const char *protocol_name = d->protocol == ORIGINAL_PROTOCOL ? "Protocol 1" : "Protocol 2";
+          snprintf(text, sizeof(text), "%s %s (P%d) %s on %s:",
                    d->name,
                    version,
-                   d->protocol == ORIGINAL_PROTOCOL ? "Protocol 1" : "Protocol 2",
+                   d->protocol == ORIGINAL_PROTOCOL ? 1 : 2,
+                   inet_ntoa(d->info.network.address.sin_addr),
+                   d->info.network.interface_name);
+          snprintf(tooltip, sizeof(tooltip), "%s\nAddress: %s\nMAC: %s\nInterface: %s",
+                   protocol_name,
                    inet_ntoa(d->info.network.address.sin_addr),
                    macStr,
                    d->info.network.interface_name);
@@ -448,12 +501,30 @@ void discovery(void) {
       }
       GtkWidget *label = gtk_label_new(text);
       gtk_widget_set_name(label, "boldlabel_blue");
+      if (tooltip[0] != '\0') {
+        gtk_widget_set_tooltip_text(label, tooltip);
+      }
+      if (d->protocol == ORIGINAL_PROTOCOL || d->protocol == NEW_PROTOCOL) {
+        set_device_label_scale(label);
+      }
       // gtk_widget_set_halign (label, GTK_ALIGN_START);
       gtk_widget_set_margin_top(label, 10);
       gtk_widget_set_halign(label, GTK_ALIGN_CENTER);
       gtk_widget_set_valign(label, GTK_ALIGN_CENTER);
       gtk_widget_show(label);
-      gtk_grid_attach(GTK_GRID(grid), label, 0, row, 3, 1);
+      GtkWidget *network_type_label = create_network_type_label(d);
+      if (network_type_label != NULL) {
+        GtkWidget *label_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
+        gtk_widget_set_halign(label_box, GTK_ALIGN_CENTER);
+        gtk_widget_set_valign(label_box, GTK_ALIGN_CENTER);
+        gtk_box_pack_start(GTK_BOX(label_box), label, FALSE, FALSE, 0);
+        gtk_widget_show(network_type_label);
+        gtk_box_pack_start(GTK_BOX(label_box), network_type_label, FALSE, FALSE, 0);
+        gtk_widget_show(label_box);
+        gtk_grid_attach(GTK_GRID(grid), label_box, 0, row, 3, 1);
+      } else {
+        gtk_grid_attach(GTK_GRID(grid), label, 0, row, 3, 1);
+      }
       GtkWidget *start_button = gtk_button_new();
       gtk_widget_set_name(start_button, "discovery_btn");
       gtk_widget_set_margin_top(start_button, 10);

--- a/src/nw_toolset.c
+++ b/src/nw_toolset.c
@@ -105,12 +105,11 @@ int nw_get_ifname_for_remote_ip(const char* remote_ip, char* ifname, size_t ifna
 }
 
 #ifdef __APPLE__
-static int nw_is_wired_macos(const char* remote_ip) {
-  char ifname[IFNAMSIZ];
+static int nw_is_wired_interface_macos(const char* ifname) {
   struct ifmediareq ifmr;
   int sock;
   int type;
-  if (nw_get_ifname_for_remote_ip(remote_ip, ifname, sizeof(ifname)) != 0) {
+  if (ifname == NULL || ifname[0] == '\0') {
     return -1;
   }
   sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -139,13 +138,12 @@ static int nw_is_wired_macos(const char* remote_ip) {
 #endif
 
 #ifdef __linux__
-static int nw_is_wired_linux(const char* remote_ip) {
-  char ifname[IFNAMSIZ];
+static int nw_is_wired_interface_linux(const char* ifname) {
   char path[256];
   FILE *fp;
   struct stat st;
   int type = -1;
-  if (nw_get_ifname_for_remote_ip(remote_ip, ifname, sizeof(ifname)) != 0) {
+  if (ifname == NULL || ifname[0] == '\0') {
     return -1;
   }
   snprintf(path, sizeof(path), "/sys/class/net/%s/wireless", ifname);
@@ -169,15 +167,21 @@ static int nw_is_wired_linux(const char* remote_ip) {
 }
 #endif
 
-int nw_is_wired(const char* remote_ip) {
+int nw_is_wired_interface(const char* ifname) {
 #ifdef __APPLE__
-  return nw_is_wired_macos(remote_ip);
+  return nw_is_wired_interface_macos(ifname);
 #elif defined(__linux__)
-  // (void)remote_ip;
-  // return 1;
-  return nw_is_wired_linux(remote_ip);
+  return nw_is_wired_interface_linux(ifname);
 #else
-  (void) remote_ip;
+  (void) ifname;
   return -1;
 #endif
+}
+
+int nw_is_wired(const char* remote_ip) {
+  char ifname[IFNAMSIZ];
+  if (nw_get_ifname_for_remote_ip(remote_ip, ifname, sizeof(ifname)) != 0) {
+    return -1;
+  }
+  return nw_is_wired_interface(ifname);
 }

--- a/src/nw_toolset.h
+++ b/src/nw_toolset.h
@@ -29,6 +29,7 @@ typedef struct {
 extern NW_SETTINGS nw_settings;
 
 int nw_is_wired (const char* remote_ip);
+int nw_is_wired_interface (const char* ifname);
 int nw_get_ifname_for_remote_ip (const char* remote_ip, char* ifname, size_t ifname_len);
 
 #endif


### PR DESCRIPTION
This PR is now narrowed to a small discovery UI improvement.

The original issue with duplicate suppression was traced to the temporary Tahoe workaround. With `TAHOEFIX=OFF`, the MacBook Pro test system shows both Wi-Fi and USB-C Ethernet discovery entries again, and upstream `master` has since removed the Tahoe fix code.

What remains here:

- Show a compact `[LAN]` or `[Wi-Fi]` label next to network-discovered radios when the interface type can be identified.
- Add a tooltip with protocol, address, MAC, and interface name.
- Preserve the existing `nw_is_wired(remote_ip)` API while adding `nw_is_wired_interface(ifname)` for cases where discovery already knows the receiving/probed interface.

This does not change discovery socket behavior or duplicate suppression.
