### PR TITLE
Fix missing display_mutex around rx_update_zoom() and two GSource lifetime bugs

### DIFF
--- a/src/radio.c
+++ b/src/radio.c
@@ -876,8 +876,16 @@ void radio_reconfigure(void) {
   y = VFO_HEIGHT;
   for (i = 0; i < receivers; i++) {
     RECEIVER *rx = receiver[i];
+    //
+    // rx->width and the pixel buffer must be updated as one atomic step with
+    // respect to the RX display timer, otherwise the draw code can observe a
+    // new width against an old (smaller) pixel_samples buffer. rx_reconfigure()
+    // takes display_mutex itself, so release it again before calling it.
+    //
+    g_mutex_lock(&rx->display_mutex);
     rx->width = my_width;
-    rx_update_zoom(rx);
+    rx_update_zoom_locked(rx);
+    g_mutex_unlock(&rx->display_mutex);
     rx_reconfigure(rx, rx_height / receivers);
     if (!radio_is_transmitting() || duplex) {
       gtk_fixed_move(GTK_FIXED(fixed), rx->panel, 0, y);

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -712,20 +712,42 @@ static int rx_update_display(gpointer data) {
       return TRUE;
     }
   }
+  //
+  // Returning FALSE destroys this GSource. rx->update_timer_id must be cleared
+  // as well, otherwise it keeps a dead source id that rx_set_displaying() will
+  // later hand to g_source_remove(). GLib recycles source ids, so that can tear
+  // down an unrelated live source (the other RX display timer, vfo_timeout,
+  // full_screen_timeout, ...) and parts of the GUI silently stop updating.
+  //
+  // Only clear it if the source being dispatched really is the one we recorded.
+  //
+  {
+    GSource *self = g_main_current_source();
+    if (self != NULL && g_source_get_id(self) == rx->update_timer_id) {
+      rx->update_timer_id = 0;
+    }
+  }
   return FALSE;
 }
 
+//
+// Tear down the RX display timer, tolerating an id that has already been
+// destroyed. Always leaves rx->update_timer_id at 0.
+//
+static void rx_remove_update_timer(RECEIVER *rx) {
+  if (rx->update_timer_id > 0) {
+    GSource *src = g_main_context_find_source_by_id(NULL, rx->update_timer_id);
+    if (src != NULL) {
+      g_source_destroy(src);
+    }
+    rx->update_timer_id = 0;
+  }
+}
+
 void rx_set_displaying(RECEIVER *rx) {
+  rx_remove_update_timer(rx);
   if (rx->displaying) {
-    if (rx->update_timer_id > 0) {
-      g_source_remove(rx->update_timer_id);
-    }
     rx->update_timer_id = gdk_threads_add_timeout_full(G_PRIORITY_HIGH_IDLE, 1000 / rx->fps, rx_update_display, rx, NULL);
-  } else {
-    if (rx->update_timer_id > 0) {
-      g_source_remove(rx->update_timer_id);
-      rx->update_timer_id = 0;
-    }
   }
 }
 
@@ -1633,13 +1655,26 @@ void rx_add_div_iq_samples(RECEIVER *rx, double i0, double q0, double i1, double
   rx_add_iq_samples(rx, i_sample, q_sample);
 }
 
-void rx_update_zoom(RECEIVER *rx) {
+void rx_update_zoom_locked(RECEIVER *rx) {
   //
   // This is called whenever rx->zoom or rx->width changes,
   // since in both cases the analyzer must be restarted.
   //
-  rx->pixels = rx->width * rx->zoom;
-  rx->hz_per_pixel = (double) rx->sample_rate / (double) rx->pixels;
+  // The caller MUST hold rx->display_mutex. That mutex is what keeps
+  // GetPixels() (which writes rx->pixels floats into rx->pixel_samples)
+  // and the panadapter/waterfall draw code away from the buffer while it
+  // is being replaced here. Without it, a zoom change coming from the
+  // rigctl/CAT thread or from a menu callback frees the buffer under a
+  // running display update, which corrupts the malloc arena and makes the
+  // whole GUI hang on the next allocation.
+  //
+  // Note the ordering below: the replacement buffer is allocated first and
+  // rx->pixels is published LAST, so rx->pixels never describes a larger
+  // buffer than the one rx->pixel_samples actually points to.
+  //
+  int new_pixels = rx->width * rx->zoom;
+  float *new_samples = g_new(float, new_pixels);
+  rx->hz_per_pixel = (double) rx->sample_rate / (double) new_pixels;
   if (rx->zoom == 1) {
     rx->pan = 0;
   } else {
@@ -1648,16 +1683,28 @@ void rx_update_zoom(RECEIVER *rx) {
       long long min_frequency = vfo[vfo_id].frequency - (long long)(rx->sample_rate / 2);
       rx->pan = ((vfo[vfo_id].ctun_frequency - min_frequency) / rx->hz_per_pixel) - (rx->width / 2);
       if (rx->pan < 0) { rx->pan = 0; }
-      if (rx->pan > (rx->pixels - rx->width)) { rx->pan = rx->pixels - rx->width; }
+      if (rx->pan > (new_pixels - rx->width)) { rx->pan = new_pixels - rx->width; }
     } else {
-      rx->pan = (rx->pixels / 2) - (rx->width / 2);
+      rx->pan = (new_pixels / 2) - (rx->width / 2);
     }
   }
   if (rx->pixel_samples != NULL) {
     g_free(rx->pixel_samples);
   }
-  rx->pixel_samples = g_new(float, rx->pixels);
+  rx->pixel_samples = new_samples;
+  rx->pixels = new_pixels;
   rx_set_analyzer(rx);
+}
+
+void rx_update_zoom(RECEIVER *rx) {
+  //
+  // Locking wrapper around rx_update_zoom_locked(). Use this one unless
+  // rx->display_mutex is already held -- GMutex is not recursive, so
+  // callers that already hold it must call rx_update_zoom_locked().
+  //
+  g_mutex_lock(&rx->display_mutex);
+  rx_update_zoom_locked(rx);
+  g_mutex_unlock(&rx->display_mutex);
 }
 
 void rx_set_filter(RECEIVER *rx) {

--- a/src/receiver.h
+++ b/src/receiver.h
@@ -417,5 +417,10 @@ extern void   rx_set_squelch(const RECEIVER *rx);
 
 extern void   rx_vfo_changed(RECEIVER *rx);
 extern void   rx_update_zoom(RECEIVER *rx);
+//
+// Same as rx_update_zoom(), but the caller must already hold
+// rx->display_mutex (GMutex is not recursive).
+//
+extern void   rx_update_zoom_locked(RECEIVER *rx);
 
 #endif

--- a/src/screen_menu.c
+++ b/src/screen_menu.c
@@ -115,6 +115,16 @@ static void cleanup(void) {
   if (dialog != NULL) {
     GtkWidget *tmp = dialog;
     dialog = NULL;
+    //
+    // Cancel any pending debounced apply(). Without this, changing a screen
+    // setting and closing the menu within 500 msec leaves a timeout armed that
+    // fires after the dialog is gone and after radio_save_state() has already
+    // written the pre-change geometry to the props file.
+    //
+    if (apply_timeout != 0) {
+      g_source_remove(apply_timeout);
+      apply_timeout = 0;
+    }
     gtk_widget_destroy(tmp);
     sub_menu = NULL;
     active_menu  = NO_MENU;

--- a/src/zoompan.c
+++ b/src/zoompan.c
@@ -216,7 +216,11 @@ static void zoom_value_changed_cb(GtkWidget *widget, gpointer data) {
   g_mutex_lock(&pan_zoom_mutex);
   g_mutex_lock(&active_receiver->display_mutex);
   active_receiver->zoom = (int)(gtk_range_get_value(GTK_RANGE(zoom_scale)) + 0.5);
-  rx_update_zoom(active_receiver);
+  //
+  // display_mutex is already held here (and stays held across the pan-range
+  // updates below), so call the non-locking variant -- GMutex is not recursive.
+  //
+  rx_update_zoom_locked(active_receiver);
   g_signal_handler_block(G_OBJECT(pan_scale), pan_signal_id);
   gtk_range_set_range(GTK_RANGE(pan_scale), 0.0,
                       (double)(active_receiver->zoom == 1 ? active_receiver->pixels : active_receiver->pixels - active_receiver->width));


### PR DESCRIPTION
### Summary

Three thread-safety defects in the RX display path. All are platform-independent; the code
touched contains no OS-specific paths.

### 1. `rx_update_zoom()` reallocates `rx->pixel_samples` without `display_mutex`

`rx->display_mutex` guards `rx->pixel_samples` / `rx->pixels` / `rx->width` against the RX
display timer. It is taken in `rx_update_display()` around `rx_get_pixels()` (i.e. around
`GetPixels()`, which writes `rx->pixels` floats into the buffer), in `rx_reconfigure()`,
and manually in `zoom_value_changed_cb()` before it calls `rx_update_zoom()`.

`rx_update_zoom()` itself does not take it, and two of its three callers do not either:

- `set_zoom()` (`zoompan.c`) — reachable from the rigctl/CAT thread (`rigctl.c`) and from
  MIDI/keyboard actions (`actions.c`)
- `radio_reconfigure()` (`radio.c`) — reachable from 8 callbacks in `display_menu.c` and 3
  in `screen_menu.c`

The function also published the new, larger `rx->pixels` *before* allocating the buffer
behind it, so a concurrent `GetPixels()` could write past the end of the old allocation.

Fix: split into `rx_update_zoom_locked()` (caller holds the lock) plus a locking
`rx_update_zoom()` wrapper — `GMutex` is not recursive, so `zoom_value_changed_cb()` uses
the `_locked` form. Allocate first, publish `rx->pixels` last. `radio_reconfigure()` now
updates `rx->width` and the buffer as one atomic step.

**This is heap corruption, not a null pointer, so the crash site is not the same as the
race site.** glibc's malloc arena is corrupted at the moment the unlocked realloc races
the display timer; the visible hang is whichever `malloc()`/`free()` call happens to run
next on the corrupted arena — anywhere in the process, at any later point. In practice
that means the freeze is not only seen right after closing a menu: it is also seen when
**exiting the app**. `main_delete()` / the Exit-menu path both call `stop_program()`
(`exit_menu.c`), which calls `radio_stop()` and then `radio_save_state()` before the
process calls `exit()` — several more `malloc()`/`free()` calls on the same arena. If the
arena was already corrupted earlier in the session, that shutdown path is simply the next
place the corruption can surface, so the app can also hang on quit rather than exiting
cleanly. Fixing the race removes the corruption at its source, which should fix both
symptoms together.

### 2. `screen_menu.c` leaves its debounced `apply_timeout` armed on close

`cleanup()` destroys the dialog without cancelling the 500 ms timeout from
`schedule_apply()`, so changing a screen setting and closing the menu within half a second
lets `apply()` run after the dialog is gone.

### 3. `rx_update_display()` leaves a dead GSource id in `rx->update_timer_id`

It returns `FALSE` — destroying its own source — when `!rx->displaying` or
`rx->pixels <= 0`, but does not clear the id. `rx_set_displaying()` then passes the stale
id to `g_source_remove()`. GLib recycles source ids, so this can remove an unrelated live
source (the other RX's display timer, `vfo_timeout`, `full_screen_timeout`). Visible as
`GLib-CRITICAL ** Source ID N was not found when attempting to remove it`.

### Testing

Built and run against current master on Linux/GTK3. No Makefile or build-script changes.
No user-visible behaviour change. I do not have a Mac to test on, but the patch touches
only portable GLib/GTK calls (`g_mutex_lock`, `g_main_current_source`,
`g_main_context_find_source_by_id`) and no `#ifdef`-guarded platform code.

---

*This patch and PR description were prepared with the assistance of Claude (Anthropic).*