### PR TITLE
HL2 local audio codec: keep the Band-Volts bit usable on SQUARE SDR 2

### DIFF
--- a/src/old_protocol.c
+++ b/src/old_protocol.c
@@ -2420,7 +2420,12 @@ void ozy_send_buffer(void) {
     // Some  HL2 firmware variants (ab-) uses this bit for indicating an audio codec is present
     // We also  accept explicit use  of the "dither" box
     //
-    if (device == DEVICE_HERMES_LITE2 && hl2_audio_codec) {
+    // NOTE: on the SQUARE SDR 2 (HL2_CODEC_SQUARESDR2) the very same bit is used
+    //       by the gateware to switch the internal loudspeaker ON/OFF. There the
+    //       bit must NOT be forced, it has to stay under control of the
+    //       "HL2 Band Volts / Dither Bit" checkbox in the RX menu.
+    //
+    if (device == DEVICE_HERMES_LITE2 && hl2_audio_codec == HL2_CODEC_AK4951) {
       output_buffer[C3] |= LT2208_DITHER_ON;
     }
     if (filter_board == CHARLY25 && receiver[0]->preamp) {

--- a/src/radio.c
+++ b/src/radio.c
@@ -191,9 +191,16 @@ int atlas_janus = 0;
 
 //
 // if hl2_audio_codec is set,  audio data is included in the HPSDR
-// data stream and the "dither" bit is set. This is used by a
-// "compagnion board" and  a variant of the HL2 firmware
-// This bit can be set in the "RADIO" menu.
+// data stream. This is used by a "compagnion board" and  a variant
+// of the HL2 firmware. This can be set in the "RADIO" menu.
+//
+// HL2_CODEC_AK4951     (HL2+ companion board): in addition the "dither"
+//                      bit is set permanently, the gateware uses it to
+//                      flag "audio codec present".
+// HL2_CODEC_SQUARESDR2 (SQUARE SDR 2, codec on the main board): the
+//                      "dither" bit is NOT touched here, in that gateware
+//                      it switches the internal loudspeaker ON/OFF and is
+//                      controlled by "HL2 Band Volts / Dither Bit" (RX menu).
 //
 // if hl2_cl1_input is set, CL1 is used as a master clock input
 // for a 10 MHz reference clock.
@@ -2810,6 +2817,10 @@ static void radio_restore_state(void) {
   GetPropI0("atlas_mic_source",                              atlas_mic_source);
   GetPropI0("atlas_janus",                                   atlas_janus);
   GetPropI0("hl2_audio_codec",                               hl2_audio_codec);
+  // sanity check, the props file may contain values from another version
+  if (hl2_audio_codec < HL2_CODEC_OFF || hl2_audio_codec > HL2_CODEC_SQUARESDR2) {
+    hl2_audio_codec = HL2_CODEC_OFF;
+  }
   GetPropI0("hl2_cl1_input",                                 hl2_cl1_input)
   GetPropI0("anan10E",                                       anan10E);
   GetPropI0("hermes_mode",                                   hermes_mode);

--- a/src/radio.h
+++ b/src/radio.h
@@ -378,6 +378,14 @@ extern double drive_digi_max;    // maximum value allowed in DIGU/DIGL
 extern gboolean display_warnings;
 extern gboolean display_pacurr;
 
+//
+// Values for hl2_audio_codec (kept numerically compatible with the
+// former ON/OFF checkbox: 0 = off, 1 = HL2+ companion board)
+//
+#define HL2_CODEC_OFF        0
+#define HL2_CODEC_AK4951     1   // HL2+ companion board: dither bit = "codec present"
+#define HL2_CODEC_SQUARESDR2 2   // SQUARE SDR 2: dither bit = internal speaker ON/OFF
+
 extern int hl2_audio_codec;
 extern int hl2_cl1_input;
 extern int anan10E;

--- a/src/radio_menu.c
+++ b/src/radio_menu.c
@@ -131,6 +131,15 @@ static void toggle_cb(GtkWidget *widget, gpointer data) {
   radio_reconfigure_screen();
 }
 
+static void hl2_codec_cb(GtkWidget *widget, gpointer data) {
+  hl2_audio_codec = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
+  schedule_general();
+  schedule_transmit_specific();
+  schedule_high_priority();
+  g_idle_add(ext_vfo_update, NULL);
+  radio_reconfigure_screen();
+}
+
 static void hermes_mode_cb(GtkWidget *widget, gpointer data) {
   int mode = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
   if (mode == hermes_mode) {
@@ -934,13 +943,24 @@ void radio_menu(GtkWidget *parent) {
   case NEW_DEVICE_HERMES_LITE2:
   case DEVICE_HERMES_LITE2: {
     if (!have_radioberry1 && !have_radioberry2 && !have_radioberry3) {
-      ChkBtn = gtk_check_button_new_with_label("HL2+ audio codec");
-      gtk_widget_set_name(ChkBtn, "boldlabel");
-      gtk_widget_set_tooltip_text(ChkBtn,
-                                  "Activate only if using a Hermes Lite 2\nwith the AK4951 Companion Board,\ncalled Hermes Lite 2 Plus");
-      gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ChkBtn), hl2_audio_codec);
-      gtk_grid_attach(GTK_GRID(grid), ChkBtn, col, row, 1, 1);
-      g_signal_connect(ChkBtn, "toggled", G_CALLBACK(toggle_cb), &hl2_audio_codec);
+      GtkWidget *codec_combo = gtk_combo_box_text_new();
+      gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(codec_combo), NULL, "No local audio codec");
+      gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(codec_combo), NULL, "HL2+ audio codec (AK4951)");
+      gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(codec_combo), NULL, "SQUARE SDR 2 audio codec");
+      gtk_widget_set_tooltip_text(codec_combo,
+                                  "Local audio codec of the HL2-compatible SDR.\n\n"
+                                  "HL2+ audio codec (AK4951):\n"
+                                  "Hermes Lite 2 with the AK4951 Companion Board.\n"
+                                  "The Dither bit is set permanently, the gateware\n"
+                                  "uses it to detect the codec.\n\n"
+                                  "SQUARE SDR 2 audio codec:\n"
+                                  "Codec on the main board. Here the Dither bit is\n"
+                                  "NOT touched, in this gateware it switches the\n"
+                                  "loudspeaker ON/OFF. Use <Speaker (Band Volts)>\n"
+                                  "in the RX menu for that.");
+      gtk_combo_box_set_active(GTK_COMBO_BOX(codec_combo), hl2_audio_codec);
+      gtk_grid_attach(GTK_GRID(grid), codec_combo, col, row, 1, 1);
+      g_signal_connect(codec_combo, "changed", G_CALLBACK(hl2_codec_cb), NULL);
       col++;
       ChkBtn = gtk_check_button_new_with_label("HL2 CL1 10Mhz Ref Clock");
       gtk_widget_set_name(ChkBtn, "boldlabel");
@@ -963,7 +983,7 @@ void radio_menu(GtkWidget *parent) {
       g_signal_connect(ChkBtn, "toggled", G_CALLBACK(toggle_cb), &enable_hl2_atu_gateware);
       col++;
     } else {
-      hl2_audio_codec = 0;
+      hl2_audio_codec = HL2_CODEC_OFF;
       hl2_cl1_input = 0;
     }
   }

--- a/src/rx_menu.c
+++ b/src/rx_menu.c
@@ -596,9 +596,25 @@ static void add_dither_random_controls(GtkWidget *grid, RECEIVER *rx, int *row) 
   rx_menu_sync_original_protocol_dither_random_from_effective();
   // We assume Dither/Random are either both available or both not available
   if (device == DEVICE_HERMES_LITE2 || device == NEW_DEVICE_HERMES_LITE2) {
-    GtkWidget *dither_b = gtk_check_button_new_with_label("HL2 Band Volts / Dither Bit");
+    //
+    // In protocol 1 the HL2 (ab-) uses the Dither bit for its "Band Volts" output.
+    // The SQUARE SDR 2 uses the very same bit to switch its loudspeaker, so if that
+    // radio is selected in the RADIO menu, name the control after what it really does.
+    //
+    const char *dither_label = "HL2 Band Volts / Dither Bit";
+    const char *dither_tip   = "activate Band Voltage output at the Hermes Lite 2";
+
+    if (hl2_audio_codec == HL2_CODEC_SQUARESDR2) {
+      dither_label = "Speaker (Band Volts)";
+      dither_tip   = "SQUARE SDR 2: switch the loudspeaker ON or OFF.\n\n"
+                     "This is the same bit the Hermes Lite 2 uses for its\n"
+                     "Band Voltage output (the Dither bit), but the SQUARE SDR 2\n"
+                     "gateware uses it to control the speaker instead.";
+    }
+
+    GtkWidget *dither_b = gtk_check_button_new_with_label(dither_label);
     gtk_widget_set_name(dither_b, "boldlabel");
-    gtk_widget_set_tooltip_text(dither_b, "activate Band Voltage output at the Hermes Lite 2");
+    gtk_widget_set_tooltip_text(dither_b, dither_tip);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(dither_b), rx->dither);
     gtk_widget_set_sensitive(dither_b, !original_protocol_rx2_global);
     gtk_grid_attach(GTK_GRID(grid), dither_b, 0, *row, 1, 1);


### PR DESCRIPTION
# HL2 local audio codec: don't force the Band-Volts/Dither bit for all codec variants

## Problem

`hl2_audio_codec` currently does two things at once in `old_protocol.c`:

1. it puts the local audio samples into the HPSDR TX data stream, and
2. it permanently forces `LT2208_DITHER_ON` in `output_buffer[C3]`.

```c
// src/old_protocol.c (before)
if (device == DEVICE_HERMES_LITE2 && hl2_audio_codec) {
  output_buffer[C3] |= LT2208_DITHER_ON;
}
```

Step 2 is correct for the **HL2+ Companion Board (AK4951)**, whose gateware (ab-)uses the
Dither bit as "audio codec present".

It is wrong for the **SQUARE SDR 2**, an HL2-compatible SDR with the audio codec on the main
board. Its gateware uses the very same bit as the **internal loudspeaker ON/OFF switch** — the
function that Thetis exposes as the "Band Volts" checkbox, and that deskHPSDR already exposes
as **Menu -> RX -> "HL2 Band Volts / Dither Bit"** (`rx_menu.c`).

Because the bit is forced high in every frame, that checkbox has no effect on such a radio:
audio works, but the loudspeaker is stuck permanently ON and can neither be switched off nor
back on from deskHPSDR.

Reported in discussion #69.

## Change

The single ON/OFF checkbox "HL2+ audio codec" in the RADIO menu becomes a three-way selection:

| Value | Meaning | Dither / Band-Volts bit |
|-------|---------|--------------------------|
| 0 `HL2_CODEC_OFF` | no local audio codec | untouched (user controlled) |
| 1 `HL2_CODEC_AK4951` | HL2+ Companion Board | forced ON (unchanged behaviour) |
| 2 `HL2_CODEC_SQUARESDR2` | SQUARE SDR 2 | untouched (user controlled -> speaker ON/OFF) |

Audio samples are sent for both codec variants exactly as before.

The property `hl2_audio_codec` keeps its numeric meaning for 0 and 1, so **existing props files
of HL2+ users continue to work unchanged** and no existing behaviour is altered. A range check
on load guards against out-of-range values.

In addition, the checkbox in the RX menu is named after what the bit actually does on the
selected radio. With the SQUARE SDR 2 codec selected it reads **"Speaker (Band Volts)"**
instead of "HL2 Band Volts / Dither Bit"; for every other HL2 the label is unchanged. Both
tooltips explain that this is physically the same bit, so the connection stays obvious.

## Files touched

- `src/radio.h` — new `HL2_CODEC_*` constants
- `src/radio.c` — updated comment, range check when loading the property
- `src/radio_menu.c` — checkbox replaced by a combo box + `hl2_codec_cb()`
- `src/rx_menu.c` — context-dependent label for the Band-Volts/Dither checkbox
- `src/old_protocol.c` — force the bit only for `HL2_CODEC_AK4951`

## Testing

Built and tested on macOS with a SQUARE SDR 2 (Protocol 1): with "SQUARE SDR 2 audio codec"
selected, audio is received from the speaker and the "Speaker (Band Volts)" checkbox switches
it ON and OFF, exactly as the "Band Volts" checkbox does in Thetis.

HL2+ Companion Board behaviour is unchanged by construction — for `hl2_audio_codec == 1` the
generated C&C bytes and the audio path are identical to before.

## References

- Band Volts == Dither bit: https://github.com/softerhardware/Hermes-Lite2/wiki/Band-Volts
- SQUARE SDR 2 ("the Band Volts checkbox switches the internal loudspeaker, band voltage
  generation is done by other hardware"): https://www.wideservis.cz/square-sdr-2/
